### PR TITLE
Made the url h5 instead of h4

### DIFF
--- a/apps-script/Dashboard.html
+++ b/apps-script/Dashboard.html
@@ -82,7 +82,7 @@
 
                 <div class="row col s12 m8 l6 offset-m2 offset-l3" align="center">
                     <div class="col s6">
-                        <h4 style="font-family: 'Bree Serif', serif; word-wrap: break-word" id='customDomain'></h4>
+                        <h5 style="font-family: 'Bree Serif', serif; word-wrap: break-word" id='customDomain'></h5>
                     </div>
                     <div class="input-field col s6">
                         <input id="slug" type="text" required />


### PR DESCRIPTION
This is so that it creates a cleaner look, instead of having it break. 

P.S. I'm not sure if you intended for the word break to happen but I think it looks better without the break.