### PR TITLE
Adding validation for long URL

### DIFF
--- a/apps-script/Code.gs
+++ b/apps-script/Code.gs
@@ -85,7 +85,17 @@ function addLink(shortStack) {
       return "Sorry! '" + slug + "' has already been taken.";
     }
   }
-  var longURL = shortStack.longURL;  
+  var longURL = shortStack.longURL;
+  
+  var urlRegex = /https?:\/\/.?(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b[-a-zA-Z0-9@:%_\+.~#?&=]*/g;
+  // Problem: https://github.com/schoraria911/gas-url-shortener/issues/19
+  // Solution: https://stackoverflow.com/questions/30970068/js-regex-url-validation
+  if (urlRegex.test(longURL)) {
+    // continue
+  } else {
+    return 'Please enter a valid URL.';
+  }
+    
   var sheetName = redirectSheet;
   var activeSheet = ss.getSheetByName(sheetName);
   if (activeSheet !== null) {


### PR DESCRIPTION
Problem: https://github.com/schoraria911/gas-url-shortener/issues/19
Solution: https://stackoverflow.com/a/30970319

The idea here is to spit out an error from the server side should it not be a valid URL and as part of checking a valid URL, it would be required for folks to enter either an http/https link.

I realise that should the regex detect a valid URL which does not start with an http/https should also be considered and an http should be prepended by default but I find that to be a bit flawed as sometimes, links that are actually on https may not have a redirect from http to https and that could cause an issue as well.