### PR TITLE
Placeholder text for long url

### DIFF
--- a/apps-script/Dashboard.html
+++ b/apps-script/Dashboard.html
@@ -75,7 +75,7 @@
 
                 <div class="row col s12 m8 l6 offset-m2 offset-l3" align="center">
                     <div class="input-field col s12">
-                        <input id="longURL" type="text" required />
+                        <input id="longURL" placeholder="Please use http:// or https://" type="text" required />
                         <label for="longURL">Long URL</label>
                     </div>
                 </div>


### PR DESCRIPTION
To help make sure there isn't any confusion when a user adds their url.